### PR TITLE
Fix/conform engine to interface

### DIFF
--- a/classes/engine.php
+++ b/classes/engine.php
@@ -46,7 +46,8 @@ class engine  extends \core_search\engine {
         return (bool)json_decode($c->get($this->serverhostname));
     }
 
-    public function add_document($doc, $fileindexing = false) {
+    public function add_document($document, $fileindexing = false) {
+        $doc = $document->export_for_engine();
         $url = $this->serverhostname.'/moodle/'.$doc['id'];
 
         $jsondoc = json_encode($doc);

--- a/classes/engine.php
+++ b/classes/engine.php
@@ -64,7 +64,11 @@ class engine  extends \core_search\engine {
     public function post_file() {
     }
 
-    public function execute_query($filters, $usercontexts) {
+    public function get_query_total_count() {
+        return \core_search\manager::MAX_RESULTS;
+    }
+
+    public function execute_query($filters, $usercontexts, $limit = 0) {
 
         // TODO: filter usercontexts.
         $search = array('query' => array('bool' => array('must' => array(array('match' => array('content' => $filters->q))))));


### PR DESCRIPTION
Implement get_query_total_count and add third parameter to execute_query to conform to \core_search\engine.

Also update add_document as the first param is an instance of \core_search\document, not an array.